### PR TITLE
Implement 2D and 3D point structs with arithmetic operations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 mod point2d;
+mod point3d;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-
+mod point2d;

--- a/src/point2d.rs
+++ b/src/point2d.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Point2D {
@@ -46,6 +46,35 @@ impl AddAssign<f64> for Point2D {
     }
 }
 
+impl Sub for Point2D {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(self.x - rhs.x, self.y - rhs.y)
+    }
+}
+
+impl SubAssign for Point2D {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.x -= rhs.x;
+        self.y -= rhs.y;
+    }
+}
+
+impl Sub<f64> for Point2D {
+    type Output = Self;
+    fn sub(self, rhs: f64) -> Self::Output {
+        Self::new(self.x - rhs, self.y - rhs)
+    }
+}
+
+impl SubAssign<f64> for Point2D {
+    fn sub_assign(&mut self, rhs: f64) {
+        self.x -= rhs;
+        self.y -= rhs;
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,5 +107,35 @@ mod tests {
         let mut p = Point2D::new(1.0, 2.0);
         p += 2.0;
         assert_eq!(p, Point2D::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn test_point_sub() {
+        let p1 = Point2D::new(4.0, 6.0);
+        let p2 = Point2D::new(1.0, 2.0);
+        let result = p1 - p2;
+        assert_eq!(result, Point2D::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn test_point_sub_scalar() {
+        let p = Point2D::new(3.0, 4.0);
+        let result = p - 2.0;
+        assert_eq!(result, Point2D::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn test_point_sub_assign() {
+        let mut p1 = Point2D::new(4.0, 6.0);
+        let p2 = Point2D::new(1.0, 2.0);
+        p1 -= p2;
+        assert_eq!(p1, Point2D::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn test_point_sub_assign_scalar() {
+        let mut p = Point2D::new(3.0, 4.0);
+        p -= 2.0;
+        assert_eq!(p, Point2D::new(1.0, 2.0));
     }
 }

--- a/src/point2d.rs
+++ b/src/point2d.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Point2D {
@@ -74,6 +74,34 @@ impl SubAssign<f64> for Point2D {
     }
 }
 
+impl Mul for Point2D {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::new(self.x * rhs.x, self.y * rhs.y)
+    }
+}
+
+impl MulAssign for Point2D {
+    fn mul_assign(&mut self, rhs: Self) {
+        self.x *= rhs.x;
+        self.y *= rhs.y;
+    }
+}
+
+impl Mul<f64> for Point2D {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self::new(self.x * rhs, self.y * rhs)
+    }
+}
+
+impl MulAssign<f64> for Point2D {
+    fn mul_assign(&mut self, rhs: f64) {
+        self.x *= rhs;
+        self.y *= rhs;
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -137,5 +165,35 @@ mod tests {
         let mut p = Point2D::new(3.0, 4.0);
         p -= 2.0;
         assert_eq!(p, Point2D::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn test_point_mul() {
+        let p1 = Point2D::new(2.0, 3.0);
+        let p2 = Point2D::new(3.0, 4.0);
+        let result = p1 * p2;
+        assert_eq!(result, Point2D::new(6.0, 12.0));
+    }
+
+    #[test]
+    fn test_point_mul_scalar() {
+        let p = Point2D::new(2.0, 3.0);
+        let result = p * 2.0;
+        assert_eq!(result, Point2D::new(4.0, 6.0));
+    }
+
+    #[test]
+    fn test_point_mul_assign() {
+        let mut p1 = Point2D::new(2.0, 3.0);
+        let p2 = Point2D::new(3.0, 4.0);
+        p1 *= p2;
+        assert_eq!(p1, Point2D::new(6.0, 12.0));
+    }
+
+    #[test]
+    fn test_point_mul_assign_scalar() {
+        let mut p = Point2D::new(2.0, 3.0);
+        p *= 2.0;
+        assert_eq!(p, Point2D::new(4.0, 6.0));
     }
 }

--- a/src/point2d.rs
+++ b/src/point2d.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Point2D {
@@ -102,6 +102,33 @@ impl MulAssign<f64> for Point2D {
     }
 }
 
+impl Div for Point2D {
+    type Output = Self;
+    fn div(self, rhs: Self) -> Self::Output {
+        Self::new(self.x / rhs.x, self.y / rhs.y)
+    }
+}
+
+impl DivAssign for Point2D {
+    fn div_assign(&mut self, rhs: Self) {
+        self.x /= rhs.x;
+        self.y /= rhs.y;
+    }
+}
+
+impl Div<f64> for Point2D {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self::Output {
+        Self::new(self.x / rhs, self.y / rhs)
+    }
+}
+
+impl DivAssign<f64> for Point2D {
+    fn div_assign(&mut self, rhs: f64) {
+        self.x /= rhs;
+        self.y /= rhs;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -195,5 +222,35 @@ mod tests {
         let mut p = Point2D::new(2.0, 3.0);
         p *= 2.0;
         assert_eq!(p, Point2D::new(4.0, 6.0));
+    }
+
+    #[test]
+    fn test_point_div() {
+        let p1 = Point2D::new(6.0, 12.0);
+        let p2 = Point2D::new(2.0, 3.0);
+        let result = p1 / p2;
+        assert_eq!(result, Point2D::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn test_point_div_scalar() {
+        let p = Point2D::new(4.0, 6.0);
+        let result = p / 2.0;
+        assert_eq!(result, Point2D::new(2.0, 3.0));
+    }
+
+    #[test]
+    fn test_point_div_assign() {
+        let mut p1 = Point2D::new(6.0, 12.0);
+        let p2 = Point2D::new(2.0, 3.0);
+        p1 /= p2;
+        assert_eq!(p1, Point2D::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn test_point_div_assign_scalar() {
+        let mut p = Point2D::new(4.0, 6.0);
+        p /= 2.0;
+        assert_eq!(p, Point2D::new(2.0, 3.0));
     }
 }

--- a/src/point2d.rs
+++ b/src/point2d.rs
@@ -1,0 +1,82 @@
+use std::ops::{Add, AddAssign};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
+pub struct Point2D {
+    x: f64,
+    y: f64,
+}
+
+impl Point2D {
+    pub fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<(f64, f64)> for Point2D {
+    fn from(p: (f64, f64)) -> Self {
+        Self::new(p.0, p.1)
+    }
+}
+
+impl Add for Point2D {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+impl AddAssign for Point2D {
+    fn add_assign(&mut self, rhs: Self) {
+        self.x += rhs.x;
+        self.y += rhs.y;
+    }
+}
+
+impl Add<f64> for Point2D {
+    type Output = Self;
+    fn add(self, rhs: f64) -> Self::Output {
+        Self::new(self.x + rhs, self.y + rhs)
+    }
+}
+
+impl AddAssign<f64> for Point2D {
+    fn add_assign(&mut self, rhs: f64) {
+        self.x += rhs;
+        self.y += rhs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_point_add() {
+        let p1 = Point2D::new(1.0, 2.0);
+        let p2 = Point2D::new(3.0, 4.0);
+        let result = p1 + p2;
+        assert_eq!(result, Point2D::new(4.0, 6.0));
+    }
+
+    #[test]
+    fn test_point_add_scalar() {
+        let p = Point2D::new(1.0, 2.0);
+        let result = p + 2.0;
+        assert_eq!(result, Point2D::new(3.0, 4.0));
+    }
+
+    #[test]
+    fn test_point_add_assign() {
+        let mut p1 = Point2D::new(1.0, 2.0);
+        let p2 = Point2D::new(3.0, 4.0);
+        p1 += p2;
+        assert_eq!(p1, Point2D::new(4.0, 6.0));
+    }
+
+    #[test]
+    fn test_point_add_assign_scalar() {
+        let mut p = Point2D::new(1.0, 2.0);
+        p += 2.0;
+        assert_eq!(p, Point2D::new(3.0, 4.0));
+    }
+}

--- a/src/point3d.rs
+++ b/src/point3d.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
+pub struct Point3D {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+impl Point3D {
+    pub fn new(x: f64, y: f64, z: f64) -> Self {
+        Self { x, y, z }
+    }
+}
+
+impl From<(f64, f64, f64)> for Point3D {
+    fn from(p: (f64, f64, f64)) -> Self {
+        Self::new(p.0, p.1, p.2)
+    }
+}

--- a/src/point3d.rs
+++ b/src/point3d.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Point3D {
     x: f64,
@@ -14,5 +16,250 @@ impl Point3D {
 impl From<(f64, f64, f64)> for Point3D {
     fn from(p: (f64, f64, f64)) -> Self {
         Self::new(p.0, p.1, p.2)
+    }
+}
+
+impl Add<f64> for Point3D {
+    type Output = Point3D;
+
+    fn add(self, rhs: f64) -> Self::Output {
+        Point3D::new(self.x + rhs, self.y + rhs, self.z + rhs)
+    }
+}
+
+impl Sub<f64> for Point3D {
+    type Output = Point3D;
+
+    fn sub(self, rhs: f64) -> Self::Output {
+        Point3D::new(self.x - rhs, self.y - rhs, self.z - rhs)
+    }
+}
+
+impl Mul<f64> for Point3D {
+    type Output = Point3D;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Point3D::new(self.x * rhs, self.y * rhs, self.z * rhs)
+    }
+}
+
+impl Div<f64> for Point3D {
+    type Output = Point3D;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        Point3D::new(self.x / rhs, self.y / rhs, self.z / rhs)
+    }
+}
+
+impl AddAssign<f64> for Point3D {
+    fn add_assign(&mut self, rhs: f64) {
+        self.x += rhs;
+        self.y += rhs;
+        self.z += rhs;
+    }
+}
+
+impl SubAssign<f64> for Point3D {
+    fn sub_assign(&mut self, rhs: f64) {
+        self.x -= rhs;
+        self.y -= rhs;
+        self.z -= rhs;
+    }
+}
+
+impl MulAssign<f64> for Point3D {
+    fn mul_assign(&mut self, rhs: f64) {
+        self.x *= rhs;
+        self.y *= rhs;
+        self.z *= rhs;
+    }
+}
+
+impl DivAssign<f64> for Point3D {
+    fn div_assign(&mut self, rhs: f64) {
+        self.x /= rhs;
+        self.y /= rhs;
+        self.z /= rhs;
+    }
+}
+
+impl Add<Point3D> for Point3D {
+    type Output = Point3D;
+
+    fn add(self, rhs: Point3D) -> Self::Output {
+        Point3D::new(self.x + rhs.x, self.y + rhs.y, self.z + rhs.z)
+    }
+}
+
+impl Sub<Point3D> for Point3D {
+    type Output = Point3D;
+
+    fn sub(self, rhs: Point3D) -> Self::Output {
+        Point3D::new(self.x - rhs.x, self.y - rhs.y, self.z - rhs.z)
+    }
+}
+
+impl Mul<Point3D> for Point3D {
+    type Output = Point3D;
+
+    fn mul(self, rhs: Point3D) -> Self::Output {
+        Point3D::new(self.x * rhs.x, self.y * rhs.y, self.z * rhs.z)
+    }
+}
+
+impl Div<Point3D> for Point3D {
+    type Output = Point3D;
+
+    fn div(self, rhs: Point3D) -> Self::Output {
+        Point3D::new(self.x / rhs.x, self.y / rhs.y, self.z / rhs.z)
+    }
+}
+
+impl AddAssign<Point3D> for Point3D {
+    fn add_assign(&mut self, rhs: Point3D) {
+        self.x += rhs.x;
+        self.y += rhs.y;
+        self.z += rhs.z;
+    }
+}
+
+impl SubAssign<Point3D> for Point3D {
+    fn sub_assign(&mut self, rhs: Point3D) {
+        self.x -= rhs.x;
+        self.y -= rhs.y;
+        self.z -= rhs.z;
+    }
+}
+
+impl MulAssign<Point3D> for Point3D {
+    fn mul_assign(&mut self, rhs: Point3D) {
+        self.x *= rhs.x;
+        self.y *= rhs.y;
+        self.z *= rhs.z;
+    }
+}
+
+impl DivAssign<Point3D> for Point3D {
+    fn div_assign(&mut self, rhs: Point3D) {
+        self.x /= rhs.x;
+        self.y /= rhs.y;
+        self.z /= rhs.z;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_scalar() {
+        let p = Point3D::new(1.0, 2.0, 3.0);
+        assert_eq!(p + 2.0, Point3D::new(3.0, 4.0, 5.0));
+    }
+
+    #[test]
+    fn test_add_point() {
+        let p1 = Point3D::new(1.0, 2.0, 3.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        assert_eq!(p1 + p2, Point3D::new(3.0, 5.0, 7.0));
+    }
+
+    #[test]
+    fn test_sub_scalar() {
+        let p = Point3D::new(1.0, 2.0, 3.0);
+        assert_eq!(p - 1.0, Point3D::new(0.0, 1.0, 2.0));
+    }
+
+    #[test]
+    fn test_sub_point() {
+        let p1 = Point3D::new(1.0, 2.0, 3.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        assert_eq!(p1 - p2, Point3D::new(-1.0, -1.0, -1.0));
+    }
+
+    #[test]
+    fn test_mul_scalar() {
+        let p = Point3D::new(1.0, 2.0, 3.0);
+        assert_eq!(p * 2.0, Point3D::new(2.0, 4.0, 6.0));
+    }
+
+    #[test]
+    fn test_mul_point() {
+        let p1 = Point3D::new(1.0, 2.0, 3.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        assert_eq!(p1 * p2, Point3D::new(2.0, 6.0, 12.0));
+    }
+
+    #[test]
+    fn test_div_scalar() {
+        let p = Point3D::new(2.0, 4.0, 6.0);
+        assert_eq!(p / 2.0, Point3D::new(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn test_div_point() {
+        let p1 = Point3D::new(2.0, 6.0, 12.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        assert_eq!(p1 / p2, Point3D::new(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn test_add_assign_scalar() {
+        let mut p = Point3D::new(1.0, 2.0, 3.0);
+        p += 2.0;
+        assert_eq!(p, Point3D::new(3.0, 4.0, 5.0));
+    }
+
+    #[test]
+    fn test_add_assign_point() {
+        let mut p1 = Point3D::new(1.0, 2.0, 3.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        p1 += p2;
+        assert_eq!(p1, Point3D::new(3.0, 5.0, 7.0));
+    }
+
+    #[test]
+    fn test_sub_assign_scalar() {
+        let mut p = Point3D::new(3.0, 4.0, 5.0);
+        p -= 2.0;
+        assert_eq!(p, Point3D::new(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn test_sub_assign_point() {
+        let mut p1 = Point3D::new(3.0, 5.0, 7.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        p1 -= p2;
+        assert_eq!(p1, Point3D::new(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn test_mul_assign_scalar() {
+        let mut p = Point3D::new(1.0, 2.0, 3.0);
+        p *= 2.0;
+        assert_eq!(p, Point3D::new(2.0, 4.0, 6.0));
+    }
+
+    #[test]
+    fn test_mul_assign_point() {
+        let mut p1 = Point3D::new(1.0, 2.0, 3.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        p1 *= p2;
+        assert_eq!(p1, Point3D::new(2.0, 6.0, 12.0));
+    }
+
+    #[test]
+    fn test_div_assign_scalar() {
+        let mut p = Point3D::new(2.0, 4.0, 6.0);
+        p /= 2.0;
+        assert_eq!(p, Point3D::new(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn test_div_assign_point() {
+        let mut p1 = Point3D::new(2.0, 6.0, 12.0);
+        let p2 = Point3D::new(2.0, 3.0, 4.0);
+        p1 /= p2;
+        assert_eq!(p1, Point3D::new(1.0, 2.0, 3.0));
     }
 }


### PR DESCRIPTION
### Description

This pull request introduces `Point2D` and `Point3D` structs with support for various arithmetic operations. The key updates include:

- **Point2D**:
  - Added a `Point2D` struct with fields `x` and `y`, representing 2D points.
  - Implemented addition, subtraction, multiplication, and division operators, along with their assignable counterparts.
  - Supported operations with both scalar values and other `Point2D` instances.
  - Added unit tests to ensure correctness of all arithmetic operations.

- **Point3D**:
  - Added a `Point3D` struct with fields `x`, `y`, and `z`, representing 3D points.
  - Implemented addition, subtraction, multiplication, and division operators, including assignable variants.
  - Supported operations with both scalar values and other `Point3D` instances.
  - Included a constructor and a `From` implementation for tuple conversion to simplify initialization.
  - Comprehensive tests added to validate the behavior.

This enhancement provides a foundation for geometric computations in two and three dimensions.